### PR TITLE
Add Assured role and update MITRE experience dates.

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
       name="description"
       content="Karl Kwon (Kyeongan Kwon, 권경안) - Software Engineer & Computer Scientist specializing in data visualization, AI, and scalable web applications. Ph.D. in Computer Science."
     />
-    <meta name="keywords" content="Karl Kwon, Kyeongan Kwon, 권경안, Karl Kwon PhD, software engineer, data visualization, AI, machine learning, computer scientist, MITRE, ScholarPlot" />
+    <meta name="keywords" content="Karl Kwon, Kyeongan Kwon, 권경안, Karl Kwon PhD, software engineer, data visualization, AI, machine learning, computer scientist, Assured, MITRE, ScholarPlot" />
     <meta name="author" content="Karl Kyeongan Kwon" />
     <meta name="robots" content="index, follow" />
 

--- a/partials/experience.html
+++ b/partials/experience.html
@@ -1,15 +1,29 @@
 <div class="experience-section">
   <div class="resume-item d-flex flex-column flex-md-row">
     <div class="resume-content">
-      <h3>Lead Software Engineer</h3>
-      <div class="subheading">MITRE – A Federally Funded Research and Development Center</div>
+      <h3>Engineering Lead</h3>
+      <div class="subheading">Assured – AI-Powered Healthcare Operations Platform, New York, NY</div>
       <ul>
-        <li>Leading the development of cutting-edge software solutions for government and defense projects.</li>
-        <li>Designing scalable architectures and optimizing performance for mission-critical applications.</li>
+        <li>Building AI-native systems for healthcare operations and workflow automation across provider network management.</li>
+        <li>Leading full-stack development with TypeScript, Python, React, and Node.js to scale credentialing, licensing, and payer enrollment.</li>
       </ul>
     </div>
     <div class="resume-date text-md-right">
-      <span>Nov 2020 - Present</span>
+      <span>May 2026 - Present</span>
+    </div>
+  </div>
+
+  <div class="resume-item d-flex flex-column flex-md-row">
+    <div class="resume-content">
+      <h3>Lead Software Engineer</h3>
+      <div class="subheading">MITRE – A Federally Funded Research and Development Center</div>
+      <ul>
+        <li>Led end-to-end engineering of web, data, and analytics solutions for national security and healthcare sectors.</li>
+        <li>Reduced analytic response time by over 40% through Python-based ETL pipelines and AI-assisted development workflows.</li>
+      </ul>
+    </div>
+    <div class="resume-date text-md-right">
+      <span>Nov 2020 - Jun 2025</span>
     </div>
   </div>
 


### PR DESCRIPTION
Reflect current Engineering Lead position at Assured and close out MITRE tenure through Jun 2025.